### PR TITLE
KaraTemplater: Rework `word` behaviour

### DIFF
--- a/src/0x.KaraTemplater.moon
+++ b/src/0x.KaraTemplater.moon
@@ -358,9 +358,9 @@ preproc_words = (line) ->
 	for i, word in ipairs line.words
 		with word
 			-- we want spaces to be a part of the text, but not contribute to metrics
-			wchars = [char for char in *.chars when not char.is_space]
-			first_char = wchars[1]
-			last_char = wchars[#wchars]
+			.wchars = [char for char in *.chars when not char.is_space]
+			first_char = .wchars[1]
+			last_char = .wchars[#.wchars]
 
 			.text = table.concat [char.text for char in *.chars]
 			.text_stripped = table.concat [char.text_stripped for char in *.chars]
@@ -380,7 +380,7 @@ preproc_words = (line) ->
 			.right = last_char.right
 			.center = (.left + .right) / 2
 
-			for char in *wchars
+			for char in *.wchars
 				.width += char.width
 				.height = math.max .height, char.height
 


### PR DESCRIPTION
Treat `word`s as siblings to `syl`s, not parents. This means that syls containing spaces will be split between the syllable border.

If some part of the old behaviour seems desirable, could consider having this alongside another type (something like `sylword`) that has that behaviour. One such case could be using `mixin syl` with `template word`s.

Main inspiration for behaviour was taken from [logarrhythimc's karaOK](https://github.com/logarrhythmic/karaOK) modified templater, but is not necessarily identical.

With this, a `word` contains its trailing whitespace (and leading whitespace only for the first word in a line), but takes its positioning and dimensions (`left`/`right`/`center`, and `width`/`height`) from the non-whitespace characters. The full characters are accessible as `word.chars`, and non-whitespace as `word.wchars` (short for word-chars)