### PR TITLE
KaraTemplater: Fix expressions for $si family

### DIFF
--- a/src/0x.KaraTemplater.moon
+++ b/src/0x.KaraTemplater.moon
@@ -754,12 +754,12 @@ eval_inline_var = (tenv) -> (var) ->
 		when '$kdur', '$sylkdur' then syl.duration / 10
 		when '$ldur' then tenv.orgline.duration
 		when '$li' then tenv.orgline.li
-		when '$si' then (tenv.orgsyl or tenv.orgchar or tenv.orgline).si
-		when '$wi' then (tenv.orgword or tenv.orgchar or tenv.orgline).wi
-		when '$ci' then (tenv.orgchar or tenv.orgsyl or tenv.orgword or tenv.orgline).ci
-		when '$cxf' then tenv.util.xf(tenv.orgchar, tenv.orgline.chars)
-		when '$sxf' then tenv.util.xf(tenv.orgsyl or tenv.orgchar.syl, tenv.orgline.syls)
-		when '$wxf' then tenv.util.xf(tenv.orgword or tenv.orgchar.word, tenv.orgline.words)
+		when '$si' then (tenv.syl or tenv.char or tenv.orgline).si
+		when '$wi' then (tenv.word or tenv.char or tenv.orgline).wi
+		when '$ci' then (tenv.char or tenv.syl or tenv.word or tenv.orgline).ci
+		when '$cxf' then tenv.util.xf(tenv.char, tenv.orgline.chars)
+		when '$sxf' then tenv.util.xf(tenv.syl or tenv.char.syl, tenv.orgline.syls)
+		when '$wxf' then tenv.util.xf(tenv.word or tenv.char.word, tenv.orgline.words)
 		else
 			if name = strip_prefix var, '$loop_'
 				tenv.loopctx.state[name] or 1


### PR DESCRIPTION
The tables for syls, chars, and words are called `orgsyl`, `orgchar`, and `orgword` internally, but inside of `tenv`, they're just called `syl`, `char`, and `word`. `tenv.orgsyl` does not exist.

Because of this, the expressions for `$si` and similar values always evaluate to `tenv.orgline.si`, although they should be `tenv.syl.si` in `template syl`'s.

This can be easily tested by making a `template syl` containing just `$si`, which will just output `1` for every syllable. There's a similar effect with `$sxf` and friends.