### PR TITLE
Fix `multi_gbc` behaviour on gradient boundaries

### DIFF
--- a/src/0x.KaraTemplater.moon
+++ b/src/0x.KaraTemplater.moon
@@ -74,7 +74,7 @@ util = (tenv) -> {
 		-- This is deeply disturbing.
 		t *= (#cs - 1) 
 
-		c1, c2 = cs[math.ceil t], cs[1 + math.ceil t]
+		c1, c2 = cs[1 + math.floor t], cs[2 + math.floor t]
 		tenv.util.gbc c1, c2, interp, t % 1
 
 	make_grad: (v1, v2, dv=1, vertical=true, loopname='grad', extend=true) ->
@@ -115,7 +115,7 @@ util = (tenv) -> {
 		if t == 1 then return cs[#cs]
 
 		t *= (#cs - 1) 
-		c1, c2 = cs[math.ceil t], cs[1 + math.ceil t]
+		c1, c2 = cs[1 + math.floor t], cs[2 + math.floor t]
 
 		interp or= guess_interp tenv, c1, c2
 		interp t % 1, c1, c2


### PR DESCRIPTION
Using `math.ceil`, a value of t=1.0 would be assigned to the _previous_ segment, but get modulo'd down to 0.0.
This makes it correctly go to the next segment.

Before:
![Sequence of I's gradiented alternating black to white. Each transition point has one glyph in the exact opposite colour](https://user-images.githubusercontent.com/5639335/177049881-6351992d-1a45-4f35-a367-709313b977dd.png)

After:
![The same sequence of I's gradiented alternating black to white, but now no glyph has an incorrect colour.](https://user-images.githubusercontent.com/5639335/177049839-51380bb2-e006-4c61-80e8-5d54c45d67a2.png)

ASS file used to generate above:
[multi_gbc overflows.ass.txt](https://github.com/The0x539/Aegisub-Scripts/files/9035181/multi_gbc.overflows.ass.txt)
```ass
Comment: 0,0:00:00.00,0:00:00.00,Default,,0,0,0,template line,{\fsp-7}
Comment: 0,0:00:00.00,0:00:00.00,Default,,0,0,0,mixin char,{\c!util.multi_gbc({"&H000000&","&HFFFFFF&","&H000000&","&HFFFFFF&","&H000000&","&HFFFFFF&","&H000000&","&HFFFFFF&","&H000000&","&HFFFFFF&"}, tenv.colorlib.interp_lch, util.cx(char))!}
Comment: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,kara,IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
```