### PR TITLE
Add `clamp` retime mode for KaraTemplater

### DIFF
--- a/doc/0x.KaraTemplater.md
+++ b/doc/0x.KaraTemplater.md
@@ -326,6 +326,7 @@ If you have any past templating experience, this function should be familiar.
 It's the most convenient way to change an output line's start/end times.
 
 I have a handful of modes that can be pretty useful and aren't necessarily available in other templaters.
+In particular, the `clamp` modes can be used to ensure other retimes don't extend the output's start/end times past the input's.
 
 | Mode                | `line.start_time = start_offset +`    | `line.end_time = end_offset +`        |
 |---------------------|---------------------------------------|---------------------------------------|
@@ -341,6 +342,14 @@ I have a handful of modes that can be pretty useful and aren't necessarily avail
 | `"preline2postsyl"` | `orgline.start_time`                  | `orgline.start_time + syl.end_time`   |
 | `"delta"`           | `line.start_time`                     | `line.end_time`                       |
 | `"set"`             | `0`                                   | `0`                                   |
+
+As a special case, `clamp` keeps the start and end times unchanged, unless they would fall outside the input line's start/end times (plus offsets, if applicable).
+Similarly, `clampsyl` does the same, but with the original syl's start/end times.
+
+| Mode                | `line.start_time = max(line.start_time,` | `line.end_time = min(line.end_time,` |
+|---------------------|------------------------------------------|--------------------------------------|
+| `"clamp"`           | `orgline.start_time + start_offset)`     | `orgline.end_time + end_offset)`     |
+| `"clampsyl"`        | `syl.start_time + start_offset)`         | `syl.end_time + end_offset)`         |
 
 ### `relayer(new_layer)`
 `line.layer = new_layer`. Enough said.

--- a/doc/0x.KaraTemplater.md
+++ b/doc/0x.KaraTemplater.md
@@ -341,7 +341,7 @@ In particular, the `clamp` modes can be used to ensure other retimes don't exten
 | `"presyl2postline"` | `orgline.start_time + syl.start_time` | `orgline.end_time`                    |
 | `"preline2postsyl"` | `orgline.start_time`                  | `orgline.start_time + syl.end_time`   |
 | `"delta"`           | `line.start_time`                     | `line.end_time`                       |
-| `"set"`             | `0`                                   | `0`                                   |
+| `"set"`, `"abs"`    | `0`                                   | `0`                                   |
 
 As a special case, `clamp` keeps the start and end times unchanged, unless they would fall outside the input line's start/end times (plus offsets, if applicable).
 Similarly, `clampsyl` does the same, but with the original syl's start/end times.

--- a/src/0x.KaraTemplater.moon
+++ b/src/0x.KaraTemplater.moon
@@ -215,6 +215,11 @@ class template_env
 				@line.end_time = end_offset
 				@line.duration = end_offset - start_offset
 				return
+			when 'clamp'
+				@line.start_time = math.max line.start_time, orgline.start_time + start_offset
+				@line.end_time = math.min line.end_time, orgline.end_time + end_offset
+				@line.duration = @line.end_time - @line.start_time
+				return
 			else error "Unknown retime mode: #{mode}", 2
 
 		orig_start = @orgline.start_time

--- a/src/0x.KaraTemplater.moon
+++ b/src/0x.KaraTemplater.moon
@@ -216,13 +216,13 @@ class template_env
 				@line.duration = end_offset - start_offset
 				return
 			when 'clamp'
-				@line.start_time = math.max line.start_time, orgline.start_time + start_offset
-				@line.end_time = math.min line.end_time, orgline.end_time + end_offset
+				@line.start_time = math.max @line.start_time, @orgline.start_time + start_offset
+				@line.end_time = math.min @line.end_time, @orgline.end_time + end_offset
 				@line.duration = @line.end_time - @line.start_time
 				return
 			when 'clampsyl'
-				@line.start_time = math.max line.start_time, syl.start_time + start_offset
-				@line.end_time = math.min line.end_time, syl.end_time + end_offset
+				@line.start_time = math.max @line.start_time, syl.start_time + start_offset
+				@line.end_time = math.min @line.end_time, syl.end_time + end_offset
 				@line.duration = @line.end_time - @line.start_time
 				return
 			else error "Unknown retime mode: #{mode}", 2

--- a/src/0x.KaraTemplater.moon
+++ b/src/0x.KaraTemplater.moon
@@ -220,6 +220,11 @@ class template_env
 				@line.end_time = math.min line.end_time, orgline.end_time + end_offset
 				@line.duration = @line.end_time - @line.start_time
 				return
+			when 'clampsyl'
+				@line.start_time = math.max line.start_time, syl.start_time + start_offset
+				@line.end_time = math.min line.end_time, syl.end_time + end_offset
+				@line.duration = @line.end_time - @line.start_time
+				return
 			else error "Unknown retime mode: #{mode}", 2
 
 		orig_start = @orgline.start_time


### PR DESCRIPTION
Adds two new `retime` modes, `clamp` and `clampsyl`, for clamping output line start and end times to those of the input.

Behavior is slightly different from other retime modes, in that offsets are applied to the "clamp times" only.
This essentially means that lines can be timed by other retimes first, then clamped, potentially with offset from the input line's times, but not affecting the start/end times of any lines that are already within the "allowed" times.