### PR TITLE
KaraTemplater: Add `nozerolen` modifier

### DIFF
--- a/doc/0x.KaraTemplater.md
+++ b/doc/0x.KaraTemplater.md
@@ -181,9 +181,9 @@ Similar to the `noblank` modifier in other templaters, but also works for mixins
 This is useful for, say, preventing a `mixin char` component from pointlessly executing for spaces.
 
 Components with the `noblank` modifier will not execute for input whose text is empty or consists entirely of whitespace.
-Unlike other templaters, this will *not* filter out syls with zero duration. For that, see `nozerolen`.
+Unlike other templaters, this will *not* filter out syls with zero duration. For that, see `nok0`.
 
-#### `nozerolen`
+#### `nok0`
 Only valid for `syl` and `char` components.
 
 Components with this modifier will not execute for syls with zero duration, or chars belonging to such a syl.

--- a/doc/0x.KaraTemplater.md
+++ b/doc/0x.KaraTemplater.md
@@ -181,6 +181,12 @@ Similar to the `noblank` modifier in other templaters, but also works for mixins
 This is useful for, say, preventing a `mixin char` component from pointlessly executing for spaces.
 
 Components with the `noblank` modifier will not execute for input whose text is empty or consists entirely of whitespace.
+Unlike other templaters, this will *not* filter out syls with zero duration. For that, see `nozerolen`.
+
+#### `nozerolen`
+Only valid for `syl` and `char` components.
+
+Components with this modifier will not execute for syls with zero duration, or chars belonging to such a syl.
 
 #### `keepspace`
 Only valid for `template`s. Primarily useful for `syl` and `word`.

--- a/src/0x.KaraTemplater.moon
+++ b/src/0x.KaraTemplater.moon
@@ -320,7 +320,7 @@ parse_templates = (subs, tenv) ->
 			keep_tags: false
 			multi: false
 			noblank: false
-			nozerolen: false
+			nok0: false
 			notext: false
 			merge_tags: true
 			strip_trailing_space: true
@@ -379,10 +379,10 @@ parse_templates = (subs, tenv) ->
 						error 'The `noblank` modifier is invalid for `once` components.'
 					component.noblank = true
 
-				when 'nozerolen'
+				when 'nok0'
 					unless classifier == 'syl' or classifier == 'char'
-						error 'The `nozerolen` modifier is only valid for `syl` and `char` components.'
-					component.nozerolen = true
+						error 'The `nok0` modifier is only valid for `syl` and `char` components.'
+					component.nok0 = true
 
 				when 'keeptags', 'multi'
 					unless classifier == 'syl'
@@ -733,7 +733,7 @@ should_eval = (component, tenv, obj, base_component) ->
 		-- No-blank filtering is irrelevant for `once` components.
 		return false if obj.is_blank or obj.is_space
 
-	if component.nozerolen
+	if component.nok0
 		-- syl objects have direct access to their duration
 		-- char objects need to fetch it from their containing syl
 		-- zero-length filtering is irrelevant for line, word, and once components


### PR DESCRIPTION
Prevents execution of components for zero-duration syllables. Name is open to discussion.

Potentially, this could be extended to lines, but I would propose a second modifier for this, as there might be cases where one would want to filter out zero-duration events on a `template char` without disabling it for zero-length syls (e.g. for punctuation).
