### PR TITLE
KaraTemplater: Implement `keeptags` modifier

### DIFF
--- a/doc/0x.KaraTemplater.md
+++ b/doc/0x.KaraTemplater.md
@@ -188,6 +188,11 @@ Only valid for `syl` and `char` components.
 
 Components with this modifier will not execute for syls with zero duration, or chars belonging to such a syl.
 
+#### `keeptags`
+Only valid for `template`s.
+By default, override tags present in the original input line will not be included in resultant output lines.
+The `keeptags` modifier will disable this behaviour, preserving input tags *other than `\k`*.
+
 #### `keepspace`
 Only valid for `template`s. Primarily useful for `syl` and `word`.
 By default, just before inserting a line of output into the file, I will trim away any trailing whitespace.

--- a/src/0x.KaraTemplater.moon
+++ b/src/0x.KaraTemplater.moon
@@ -613,7 +613,7 @@ preproc_chars = (line) ->
 	for syl in *line.syls
 		syl.chars = {}
 
-		-- Map override blocks `{...}` to their char index within the stripped syl
+		-- Map override blocks `{...}` to their char's index within the stripped line
 		-- Potential differential issue between lua chars and unicode.chars
 		tags = {}
 		cum_offset = 0

--- a/src/0x.KaraTemplater.moon
+++ b/src/0x.KaraTemplater.moon
@@ -394,10 +394,15 @@ parse_templates = (subs, tenv) ->
 						error 'The `nok0` modifier is only valid for `syl` and `char` components.'
 					component.nok0 = true
 
-				when 'keeptags', 'multi'
+				when 'multi'
 					unless classifier == 'syl'
 						error "The `#{modifier}` modifier is only valid for `syl` components."
 					error "The `#{modifier}` modifier is not yet implemented."
+
+				when 'keeptags'
+					unless line_type == 'template'
+						error 'The `keeptags` modifier is only valid for templates.'
+					component.keeptags = true
 
 				when 'notext'
 					unless line_type == 'template'
@@ -607,9 +612,19 @@ preproc_chars = (line) ->
 	left = 0
 	for syl in *line.syls
 		syl.chars = {}
+
+		-- Map override blocks `{...}` to their char index within the stripped syl
+		-- Potential differential issue between lua chars and unicode.chars
+		tags = {}
+		cum_offset = 0
+		for ovr_blocks, syl_offset in syl.text\gmatch('({.-})()[^{}]') -- captures: contiguous override blocks preceding a char; char index within syl
+			cum_offset += #ovr_blocks
+			tags[i-1 + syl_offset - cum_offset] = ovr_blocks
+
 		for ch in unicode.chars syl.text_stripped
 			char = {:syl, :line, :i}
-			char.text = ch
+			char.text = (tags[i] or '') .. ch
+			char.text_stripped = ch
 			char.is_space = (ch == ' ' or ch == '\t') -- matches karaskel behavior
 			char.chars = {char}
 
@@ -877,7 +892,7 @@ build_text = (prefix, chars, tags, template) ->
 		if tags[char.ci] != nil
 			table.insert segments, tag for tag in *tags[char.ci]
 		unless template.notext
-			table.insert segments, char.text
+			table.insert segments, template.keeptags and char.text or char.text_stripped
 
 	table.concat segments
 


### PR DESCRIPTION
The `keeptags` modifier flags that non-k override tags from an input line should be preserved when generating resultant output lines.

The tags are extracted via `preproc_chars`; we match for override blocks in a `syl`, map which character they belong to, and prepend the blocks to `char.text`.
Notably, this process is performed regardless of `keeptags`. `keeptags` merely indicates if the output should be stripped or not.

As `char` previously only defined `char.text`, I have renamed what was `char.text` to `char.text_stripped`, with `char.text` now representing the character including tags. This makes it consistent with the other classes, but will be potentially breaking for old component lines expecting `char.text` to be stripped. An alternative could be storing tags in `char.tags`, leaving `char.text` untouched. I prefer the consistent fields, but I'll RFC for now.

A bug with `word.text_stripped` is also indirectly fixed, which relied on an undefined `char.text_stripped` - causing the string to always be `nil`.