### PR TITLE
KaraTemplater: Add conventional script properties

### DIFF
--- a/src/0x.KaraTemplater.moon
+++ b/src/0x.KaraTemplater.moon
@@ -1,3 +1,9 @@
+export script_name = '0x539\'s Templater'
+export script_description = ''
+export script_author = 'The0x539'
+export script_version = '0.1.0'
+export script_namespace = '0x.KaraTemplater'
+
 require 'karaskel'
 
 try_import = (name) ->
@@ -1080,7 +1086,7 @@ can_remove = (subs, _sel, _active) ->
 			return true
 	return false
 
-aegisub.register_macro '0x539\'s Templater', 'no description', main, can_apply
+aegisub.register_macro script_name, 'Run the templater', main, can_apply
 aegisub.register_macro 'Remove generated fx', 'Remove non-commented lines whose Effect field is `fx`', remove_fx_main, can_remove
 
 print_stacktrace = ->


### PR DESCRIPTION
In particular, `script_namespace` must be defined to import DC-based modules (such as Functional) in scripts, for the logger to work.
`script_version` was picked arbitrarily to be a pre-1.0 version, but is not really necessary.